### PR TITLE
Do not convert type-check-function into array

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = function(bodyParser) {
     options = options || {};
 
     options.type = options.type || DEFAULT_TYPES;
-    if(!Array.isArray(options.type)) {
+    if(typeof options.type !== 'function' && !Array.isArray(options.type)) {
       options.type = [options.type];
     }
 

--- a/test.js
+++ b/test.js
@@ -93,7 +93,7 @@ describe('XML Body Parser', function() {
 
   it('should accept custom ContentType as function', function(done) {
     createServer({
-      type: () => true
+      type: function() { return true }
     });
     request(app)
         .post('/')

--- a/test.js
+++ b/test.js
@@ -55,7 +55,7 @@ describe('XML Body Parser', function() {
   });
 
   it('should accept xmlParseOptions', function(done) {
-   createServer({
+    createServer({
       xmlParseOptions: {
         normalize: true,     // Trim whitespace inside text nodes
         normalizeTags: true, // Transform tags to lowercase
@@ -87,6 +87,16 @@ describe('XML Body Parser', function() {
     request(app)
         .post('/')
         .set('Content-Type', 'application/custom-xml-type')
+        .send('<customer><name>Bob</name></customer>')
+        .expect(200, { parsed: { customer: { name: ['Bob'] } } }, done);
+  });
+
+  it('should accept custom ContentType as function', function(done) {
+    createServer({
+      type: () => true
+    });
+    request(app)
+        .post('/')
         .send('<customer><name>Bob</name></customer>')
         .expect(200, { parsed: { customer: { name: ['Bob'] } } }, done);
   });


### PR DESCRIPTION
Allows bodyparser.text to use your custom type-check-function and resolves #5 