### PR TITLE
Fix prototype pollution vulnerability

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,9 +43,18 @@ module.exports = function (bodyParser) {
             return next(err);
           }
 
-          // Set the prototype of parsed xml object to null, so that prototype pollution is prevented.
-          xml.__proto__ = undefined;
-          req.body = xml || req.body;
+          // Prevent setting __proto__ and constructor.prototype
+          const safe = {};
+          for (const key in xml) {
+            if (
+              key !== '__proto__' &&
+              key !== 'constructor' &&
+              key !== 'prototype'
+            ) {
+              safe[key] = xml[key];
+            }
+          }
+          req.body = safe || req.body;
           next();
         });
       });

--- a/index.js
+++ b/index.js
@@ -44,12 +44,12 @@ module.exports = function (bodyParser) {
           }
 
           // Prevent setting __proto__ and constructor.prototype
-          if(xml) {
+          if (xml) {
             // Guard against prototype pollution
             delete xml.__proto__;
             delete xml.constructor;
             delete xml.prototype;
-  
+
             req.body = xml;
           }
           next();

--- a/index.js
+++ b/index.js
@@ -44,17 +44,14 @@ module.exports = function (bodyParser) {
           }
 
           // Prevent setting __proto__ and constructor.prototype
-          const safe = {};
-          for (const key in xml) {
-            if (
-              key !== '__proto__' &&
-              key !== 'constructor' &&
-              key !== 'prototype'
-            ) {
-              safe[key] = xml[key];
-            }
+          if(xml) {
+            // Guard against prototype pollution
+            delete xml.__proto__;
+            delete xml.constructor;
+            delete xml.prototype;
+  
+            req.body = xml;
           }
-          req.body = safe || req.body;
           next();
         });
       });

--- a/index.js
+++ b/index.js
@@ -43,6 +43,8 @@ module.exports = function (bodyParser) {
             return next(err);
           }
 
+          // Set the prototype of parsed xml object to null, so that prototype pollution is prevented.
+          xml.__proto__ = undefined;
           req.body = xml || req.body;
           next();
         });

--- a/test.js
+++ b/test.js
@@ -131,12 +131,30 @@ describe('XML Body Parser', function () {
       .expect(400, done);
   });
 
-  it('should not set/change prototype', function (done) {
+  it('should not set/change prototype using __proto__', function (done) {
     createServer();
     request(app)
       .post('/')
       .set('Content-Type', 'application/xml')
       .send('<__proto__><name>Bob</name></__proto__>')
-      .expect(200, { parsed: { name: ['Bob'] } }, done);
+      .expect(200, { parsed: {} }, done);
+  });
+
+  it('should not set/change using __proto__', function (done) {
+    createServer();
+    request(app)
+      .post('/')
+      .set('Content-Type', 'application/xml')
+      .send('<prototype><name>Bob</name></prototype>')
+      .expect(200, { parsed: {} }, done);
+  });
+
+  it('should not set/change using constructor', function (done) {
+    createServer();
+    request(app)
+      .post('/')
+      .set('Content-Type', 'application/xml')
+      .send('<constructor><name>Bob</name></constructor>')
+      .expect(200, { parsed: {} }, done);
   });
 });

--- a/test.js
+++ b/test.js
@@ -130,4 +130,13 @@ describe('XML Body Parser', function () {
       .send('x<foo>test</foo><bar>test</bar></data>')
       .expect(400, done);
   });
+
+  it('should not set/change prototype', function (done) {
+    createServer();
+    request(app)
+      .post('/')
+      .set('Content-Type', 'application/xml')
+      .send('<__proto__><name>Bob</name></__proto__>')
+      .expect(200, { parsed: { name: ['Bob'] } }, done);
+  });
 });


### PR DESCRIPTION
Set the prototype of parsed xml object to undefined, so that prototype pollution is prevented. 